### PR TITLE
Remove alternate repo url

### DIFF
--- a/coreos/coreos-arm64-howto.txt
+++ b/coreos/coreos-arm64-howto.txt
@@ -55,8 +55,7 @@ Follow the CoreOS SDK instructions here:
 
 But use my manifest when initializing your local repositories:
 
-  repo init -u https://github.com/glevand/coreos--manifest.git -g minilayout \
-    --repo-url https://chromium.googlesource.com/external/repo.git
+  repo init -u https://github.com/glevand/coreos--manifest.git
   repo sync
 
 The board name is 'arm64-usr'.  Either setup a .default_board file:


### PR DESCRIPTION
Specifying the chromium copy of repo has never been required and finally
removed from our own documentation: https://github.com/coreos/docs/pull/469